### PR TITLE
Correct bucket encryption in sam template

### DIFF
--- a/sam/template.yaml
+++ b/sam/template.yaml
@@ -144,9 +144,8 @@ Resources:
               - HEAD
             AllowedOrigins:
               - "*"
-      EncryptionConfiguration:
+      BucketEncryption:
         ServerSideEncryptionConfiguration:
-          Rules:
             - ServerSideEncryptionByDefault:
                 SSEAlgorithm: "AES256"
 


### PR DESCRIPTION
*Issue #, if available:*
NA
*Description of changes:*
EncryptionConfiguration and "Rules" in SAM template raised encryption properties errors in Cloudformation follow by rollback. Reviewing the latest S3 Cloudformation reference i found that the proposed change fix the problem.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
